### PR TITLE
Use ident option from network settings

### DIFF
--- a/identd.cc
+++ b/identd.cc
@@ -260,10 +260,7 @@ void IdentSock::ReadLine(const CS_STRING& line)
 		auto network = sock->GetNetwork();
 		DEBUG("identd: found IRC socket for " + network->GetUser()->GetUserName() + "/" + network->GetName() + " on " + GetLocalIP() + ":" + CString(port));
 
-		CString sIdent = network->GetIdent();
-		if (sIdent.empty())
-			sIdent = network->GetUser()->GetIdent();
-		reply += "USERID : UNIX : " + sIdent;
+		reply += "USERID : UNIX : " + network->GetIdent();
 	}
 	else
 	{

--- a/identd.cc
+++ b/identd.cc
@@ -260,7 +260,10 @@ void IdentSock::ReadLine(const CS_STRING& line)
 		auto network = sock->GetNetwork();
 		DEBUG("identd: found IRC socket for " + network->GetUser()->GetUserName() + "/" + network->GetName() + " on " + GetLocalIP() + ":" + CString(port));
 
-		reply += "USERID : UNIX : " + network->GetUser()->GetIdent();
+		CString sIdent = network->GetIdent();
+		if (sIdent.empty())
+			sIdent = network->GetUser()->GetIdent();
+		reply += "USERID : UNIX : " + sIdent;
 	}
 	else
 	{


### PR DESCRIPTION
Adds support for this mod to reply with the ident value set in the network config, instead of in the user config. In case the network has no value set for ident, it will [fallback to the value set in the user config](https://github.com/cynix/znc-identd/pull/1#discussion_r2009001396).

Although this may be understood to be against the spirit of what the ident service is, there are plenty of ways to spoof it already now days. If a ZNC admin does not want an unprivileged user to spoof idents, there is already an option to deny them access to change it.